### PR TITLE
Fix package name as bazelrc not parser

### DIFF
--- a/bazelrc/command_line.go
+++ b/bazelrc/command_line.go
@@ -1,4 +1,4 @@
-package parser
+package bazelrc
 
 import (
 	"fmt"

--- a/bazelrc/command_line_test.go
+++ b/bazelrc/command_line_test.go
@@ -1,4 +1,4 @@
-package parser
+package bazelrc
 
 import (
 	"testing"

--- a/bazelrc/contents.go
+++ b/bazelrc/contents.go
@@ -1,4 +1,4 @@
-package parser
+package bazelrc
 
 // BazelrcContents holds the output of parsing a Bazelrc file.
 type BazelrcContents struct {

--- a/bazelrc/datatables.go
+++ b/bazelrc/datatables.go
@@ -1,4 +1,4 @@
-package parser
+package bazelrc
 
 import (
 	"bytes"

--- a/bazelrc/parser.go
+++ b/bazelrc/parser.go
@@ -1,4 +1,4 @@
-package parser
+package bazelrc
 
 import (
 	"fmt"

--- a/bazelrc/parser_test.go
+++ b/bazelrc/parser_test.go
@@ -1,4 +1,4 @@
-package parser
+package bazelrc
 
 import (
 	"fmt"


### PR DESCRIPTION
This was a mistake from the export process.