### PR TITLE
build(gazelle): move to import_alias go_naming_convention

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,8 @@
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
-load("//:format.bzl", "format_test")
 load("@gazelle//:def.bzl", "gazelle")
+load("//:format.bzl", "format_test")
 
+# gazelle:go_naming_convention import_alias
 gazelle(name = "gazelle")
 
 # Run `bazel run //:format` to format all source code in this repo.

--- a/bazelrc/BUILD.bazel
+++ b/bazelrc/BUILD.bazel
@@ -1,8 +1,8 @@
-load("//:format.bzl", "format_test")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//:format.bzl", "format_test")
 
 go_library(
-    name = "go_default_library",
+    name = "bazelrc",
     srcs = [
         "command_line.go",
         "contents.go",
@@ -13,22 +13,28 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//bazel_protos/bazel_flags:bazel_flags_go_proto",
-        "@com_github_google_shlex//:go_default_library",
-        "@org_golang_google_protobuf//proto:go_default_library",
-        "@org_golang_x_exp//slices:go_default_library",
+        "@com_github_google_shlex//:shlex",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_x_exp//slices",
     ],
 )
 
+alias(
+    name = "go_default_library",
+    actual = ":bazelrc",
+    visibility = ["//visibility:public"],
+)
+
 go_test(
-    name = "go_default_test",
+    name = "bazelrc_test",
     srcs = [
         "command_line_test.go",
         "parser_test.go",
     ],
     data = glob(["testdata/**"]),
-    embed = [":go_default_library"],
+    embed = [":bazelrc"],
     deps = [
-        "@com_github_stretchr_testify//require:go_default_library",
+        "@com_github_stretchr_testify//require",
         "@rules_go//go/runfiles:go_default_library",
     ],
 )


### PR DESCRIPTION
This allows for a transition period until migrating to the "import" naming convention that is now the default for new projects.