### PR TITLE
Fix the GHA workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: bazelbuild/setup-bazelisk@v2
+      - uses: actions/checkout@v4
       - name: bazel test ...
         run: bazel test //... --test_output=errors


### PR DESCRIPTION
The `bazelbuild/setup-bazelisk@v2` action has now been marked read-only, but we no longer need it as the GHA runners already ship with `bazelisk` installed.